### PR TITLE
Add documentation to rest_listen_uri

### DIFF
--- a/graylog2.conf.example
+++ b/graylog2.conf.example
@@ -22,8 +22,10 @@ root_password_sha2 =
 # Set plugin directory here (relative or absolute)
 plugin_dir = plugin
 
-# REST API listen URI. Must be reachable by other graylog2-server nodes if you run a cluster.
+# REST API listen URI. Must be reachable by other graylog2-server nodes if you run a cluster. This must
+# also be reachable by collectors so that hearbeat messages can be received.
 rest_listen_uri = http://127.0.0.1:12900/
+
 # REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
 # is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
 # This will be promoted in the cluster discovery APIs and other nodes may try to connect on this


### PR DESCRIPTION
rest_listen_uri is also applicable to collectors connecting to the server. The collectors send PUT hearbeat messages to the server's rest interface. (as of  v1.3.3 and collector v0.4.2)